### PR TITLE
optimize memory usage

### DIFF
--- a/HappyTravel.HttpRequestLogger/HappyTravel.HttpRequestLogger.csproj
+++ b/HappyTravel.HttpRequestLogger/HappyTravel.HttpRequestLogger.csproj
@@ -7,12 +7,12 @@
         <Company>HappyTravel</Company>
         <Authors>Vadim Mingazhev</Authors>
         <Description>Configurable http-request logging handler</Description>
-        <PackageReleaseNotes>Added chaining ability</PackageReleaseNotes>
+        <PackageReleaseNotes>Moved logged data to scope</PackageReleaseNotes>
         <PackageProjectUrl>https://github.com/happy-travel/http-request-logging-handler</PackageProjectUrl>
         <RepositoryURL>https://github.com/happy-travel/http-request-logging-handler</RepositoryURL>
-        <Version>0.9.0</Version>
+        <Version>0.10.0</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>0.9.0</PackageVersion>
+        <PackageVersion>0.10.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/HappyTravel.HttpRequestLogger/HttpRequestLoggingHandler.cs
+++ b/HappyTravel.HttpRequestLogger/HttpRequestLoggingHandler.cs
@@ -117,13 +117,8 @@ namespace HappyTravel.HttpRequestLogger
 
             var sb = new StringBuilder();
 
-            foreach (var (key, value) in dictionary)
-            {
-                sb.Append(key);
-                sb.Append(':');
-                sb.Append(value);
-                sb.AppendLine();
-            }
+            foreach (var (key, value) in dictionary) 
+                sb.AppendFormat("{0}: {1}{2}", key, value, Environment.NewLine);
 
             return sb.ToString();
         }

--- a/HappyTravel.HttpRequestLogger/HttpRequestLoggingHandler.cs
+++ b/HappyTravel.HttpRequestLogger/HttpRequestLoggingHandler.cs
@@ -87,13 +87,14 @@ namespace HappyTravel.HttpRequestLogger
 
             void WriteLog(HttpRequestLogEntry entry, Exception? exception = null)
             {
+                var sb = new StringBuilder();
                 var data = new Dictionary<string, object>
                 {
                     ["Method"] = entry.Method,
                     ["Url"] = entry.Url,
-                    ["RequestHeaders"] = ConvertToString(entry.RequestHeaders),
+                    ["RequestHeaders"] = ConvertToString(entry.RequestHeaders, sb),
                     ["RequestBody"] = entry.RequestBody ?? string.Empty,
-                    ["ResponseHeaders"] = ConvertToString(entry.ResponseHeaders),
+                    ["ResponseHeaders"] = ConvertToString(entry.ResponseHeaders, sb),
                     ["ResponseBody"] = entry.ResponseBody ?? string.Empty,
                     ["StatusCode"] = entry.StatusCode.ToString()
                 };
@@ -110,12 +111,12 @@ namespace HappyTravel.HttpRequestLogger
                 h => string.Join(";", h.Value));
         }
 
-        private static string ConvertToString(Dictionary<string, string>? dictionary)
+        private static string ConvertToString(Dictionary<string, string>? dictionary, StringBuilder sb)
         {
             if (dictionary is null)
                 return string.Empty;
 
-            var sb = new StringBuilder();
+            sb.Clear();
 
             foreach (var (key, value) in dictionary) 
                 sb.AppendFormat("{0}: {1}{2}", key, value, Environment.NewLine);

--- a/HappyTravel.HttpRequestLogger/Infrastructure/LoggerExtensions.g.cs
+++ b/HappyTravel.HttpRequestLogger/Infrastructure/LoggerExtensions.g.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace HappyTravel.HttpRequestLogger.Infrastructure
+{
+    public static class LoggerExtensions
+    {
+        static LoggerExtensions()
+        {
+            HttpRequestLogging = LoggerMessage.Define(LogLevel.Information,
+                new EventId(120000, "HttpRequestLogging"),
+                "Http request logging");
+            
+        }
+    
+                
+         public static void LogHttpRequestLogging(this ILogger logger, Exception exception = null)
+            => HttpRequestLogging(logger, exception);
+    
+    
+        
+        private static readonly Action<ILogger, Exception> HttpRequestLogging;
+    }
+}

--- a/HappyTravel.HttpRequestLogger/Infrastructure/logEvents.json
+++ b/HappyTravel.HttpRequestLogger/Infrastructure/logEvents.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 120000,
+    "name": "HttpRequestLogging",
+    "level": "Information",
+    "template": "Http request logging"
+  }
+]


### PR DESCRIPTION
In structural logging message is decomposed
Final message, original message and each variable will be logged separately
Each of them will allocate memory
So, huge response body in message will be allocated twice